### PR TITLE
Fixes Tab Styling

### DIFF
--- a/PageReferencesTab.module
+++ b/PageReferencesTab.module
@@ -119,7 +119,12 @@ class PageReferencesTab extends WireData implements Module, ConfigurableModule {
 
 		// append the markup to the tab and the tab to the form
 		$refTab->append($field);
-		$form->append($refTab);
+		// Processwire handles tabs differently depending on the version 
+		if(ProcessWire::versionMajor == 2 && ProcessWire::versionMinor <= 4){
+			$form->append($refTab);
+		} else {
+			$form->prepend($refTab);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This fixes https://github.com/niklaka/PageReferencesTab/issues/1 and part of https://github.com/niklaka/PageReferencesTab/issues/3

Before the PR, the tab styling didn't look right.  Now it does.

I tested this on 2.8.30 and 3.071

![edit page about pw3 dev 2017-08-30 15-44-42](https://user-images.githubusercontent.com/40570/29894226-35114356-8d9a-11e7-8604-e5eed4cc7f47.jpg)
